### PR TITLE
Adjust frame control for iOS

### DIFF
--- a/CodingCoach/CodingCoach/CustomControls/TagsView.xaml.cs
+++ b/CodingCoach/CodingCoach/CustomControls/TagsView.xaml.cs
@@ -36,6 +36,7 @@ namespace CodingCoach.CustomControls
          };
          var frame = new Frame
          {
+             HasShadow = false,
             @class = new List<string>
             {
                "mentor-tag-container"

--- a/CodingCoach/CodingCoach/Views/ItemsPage.xaml
+++ b/CodingCoach/CodingCoach/Views/ItemsPage.xaml
@@ -1,4 +1,4 @@
-﻿<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:abstractions="clr-namespace:ImageCircle.Forms.Plugin.Abstractions;assembly=ImageCircle.Forms.Plugin"
              xmlns:customControls="clr-namespace:CodingCoach.CustomControls;assembly=CodingCoach"
@@ -30,6 +30,7 @@
                                 Grid.Row="0"
                                 Padding="0,55,0,10">
                                 <Frame BackgroundColor="Transparent"
+                                       HasShadow="false"
                                        class="mentor-card">
                                     <StackLayout Padding="5,45,5,10"
                                                  Orientation="Vertical">


### PR DESCRIPTION
Using the frame with default properties will create an unpleasing shadow on iOS.
Setting the hasShadow to false will fix this.