### PR TITLE
Span CSS Styles

### DIFF
--- a/CodingCoach/CodingCoach/Assets/contactPage.css
+++ b/CodingCoach/CodingCoach/Assets/contactPage.css
@@ -1,0 +1,13 @@
+﻿.linkLabel {
+    text-decoration: underline;
+}
+
+.emailLabel {
+    color: #69d5b1;
+}
+
+flexLayout {
+    margin: 20;
+    flex-direction: row;
+    flex-wrap: wrap;
+}

--- a/CodingCoach/CodingCoach/Views/ContactPage.xaml
+++ b/CodingCoach/CodingCoach/Views/ContactPage.xaml
@@ -8,27 +8,37 @@
     <ContentPage.BindingContext>
         <vm:ContactViewModel />
     </ContentPage.BindingContext>
-    
+    <ContentPage.Resources>
+        <StyleSheet Source="../Assets/contactPage.css"/>
+    </ContentPage.Resources>
     <ContentPage.Content>
-        <StackLayout Margin="20">
-            <Label>
-                <Label.FormattedText>
-                    <FormattedString>
-                        <Span Text="We want to hear your thoughts! Feel free to join our " />
-                        <Span Text="Slack Organization" TextDecorations="Underline">
-                            <Span.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding SlackCommand}" />
-                            </Span.GestureRecognizers>
-                        </Span>
-                        <Span Text=" or send us an email at " />
-                        <Span Text="codingcoachio@gmail.com" TextColor="#69d5b1">
-                            <Span.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding EmailCommand}" />
-                            </Span.GestureRecognizers>
-                        </Span>
-                    </FormattedString>
-                </Label.FormattedText>
-            </Label>
+        <StackLayout>
+            <FlexLayout>
+                <Label Text="We want to hear your thoughts! Feel free to join our " />
+                <Label StyleClass="linkLabel">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="Slack Organization">
+                                <Span.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding SlackCommand}" />
+                                </Span.GestureRecognizers>
+                            </Span>
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+                <Label Text=" or send us an email at " />
+                <Label StyleClass="emailLabel">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="codingcoachio@gmail.com">
+                                <Span.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding EmailCommand}" />
+                                </Span.GestureRecognizers>
+                            </Span>
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+            </FlexLayout>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>


### PR DESCRIPTION
🐛 CSS is not working for `Span` because they are translated into `Label` before CSS are parsed in runtime.

After some time with attempts and errors and ...  And here is and proposal solution for weird spans ✨💥 


